### PR TITLE
Exposed the fields of the `Event` struct to have public visibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ let event = client.wait();
 This returns an `Event` structure:
 ```rust
 pub struct Event {
-    subject: String,
-    channel: Channel,
-    msg: Vec<u8>,
-    inbox: Option<String>
+    pub subject: String,
+    pub channel: Channel,
+    pub msg: Vec<u8>,
+    pub inbox: Option<String>
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,15 +76,15 @@ struct ConnectWithCredentials {
 
 #[derive(Debug)]
 pub struct Channel {
-    sid: u64
+    pub sid: u64
 }
 
 #[derive(Debug)]
 pub struct Event {
-    subject: String,
-    channel: Channel,
-    msg: Vec<u8>,
-    inbox: Option<String>
+    pub subject: String,
+    pub channel: Channel,
+    pub msg: Vec<u8>,
+    pub inbox: Option<String>
 }
 
 pub struct Events<'t> {


### PR DESCRIPTION
Exposed the fields of the `Event` struct to have public visibility.

Currently they are private which makes them useless when using this library.
The README makes it seem like they are intended to be public.
