### PR TITLE
Add TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ rand = "~0.3"
 serde = "~0.8"
 serde_json = "~0.8"
 url = "~1.3"
+openssl = "0.9.16"
 
 clippy = {version = ">=0", optional = true}

--- a/src/client.rs
+++ b/src/client.rs
@@ -460,7 +460,11 @@ impl Client {
         let servers_count = self.servers_info.len();
         for _ in 0..CIRCUIT_BREAKER_ROUNDS_BEFORE_BREAKING {
             for _ in 0..servers_count {
-                if self.try_connect().is_ok() {
+                let result = self.try_connect();
+                if let Err(true) = result.as_ref().map_err(|e| e.kind() == TlsError) {
+                    return result;
+                }
+                if result.is_ok() {
                     if self.state.is_none() {
                         panic!("Inconsistent state");
                     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 extern crate url;
+extern crate openssl;
 
 use std::fmt;
 use std::error::Error;
@@ -15,6 +16,7 @@ pub enum ErrorKind {
     InvalidSchemeError,
     ServerProtocolError,
     TypeError,
+    TlsError,
 }
 
 #[derive(Debug)]
@@ -91,6 +93,18 @@ impl From<io::Error> for NatsError {
     fn from(e: io::Error) -> NatsError {
         NatsError {
             repr: ErrorRepr::IoError(e),
+        }
+    }
+}
+
+impl From<openssl::error::ErrorStack> for NatsError {
+    fn from(e: openssl::error::ErrorStack) -> NatsError {
+        NatsError {
+            repr: ErrorRepr::WithDescriptionAndDetail(
+                ErrorKind::TlsError,
+                "",
+                e.description().to_owned(),
+            ),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,17 @@ pub struct NatsError {
     repr: ErrorRepr,
 }
 
+impl NatsError {
+    pub fn kind(&self) -> ErrorKind {
+        match self.repr {
+            ErrorRepr::WithDescription(kind, _) |
+            ErrorRepr::WithDescriptionAndDetail(kind, _, _) => kind,
+            ErrorRepr::IoError(_) => ErrorKind::IoError,
+            ErrorRepr::UrlParseError(_) => ErrorKind::InvalidSchemeError,
+        }
+    }
+}
+
 impl Error for NatsError {
     fn description(&self) -> &str {
         match self.repr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,13 @@
 
 extern crate serde;
 extern crate serde_json;
+pub extern crate openssl;
 
 pub use client::*;
 pub use errors::*;
+pub use tls_config::*;
 
 mod client;
 mod errors;
 mod stream;
+mod tls_config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub use errors::*;
 
 mod client;
 mod errors;
+mod stream;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,85 @@
+extern crate openssl;
+
+use std::io;
+use std::net::TcpStream;
+use std::sync::{Arc, Mutex};
+use self::openssl::ssl;
+
+use self::Stream::{Tcp, Ssl};
+
+#[derive(Debug)]
+pub enum Stream {
+    Tcp(TcpStream),
+    Ssl(SslStream),
+}
+
+impl Stream {
+    pub fn try_clone(&self) -> io::Result<Stream> {
+        match *self {
+            Tcp(ref s) => Ok(Tcp(try!(s.try_clone()))),
+            Ssl(ref s) => Ok(Ssl(s.clone())),
+        }
+    }
+
+    pub fn as_tcp(&self) -> io::Result<TcpStream> {
+        match *self {
+            Tcp(ref s) => s.try_clone(),
+            Ssl(ref s) => s.as_tcp(),
+        }
+    }
+}
+
+impl io::Read for Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            Tcp(ref mut s) => s.read(buf),
+            Ssl(ref mut s) => s.read(buf),
+        }
+    }
+}
+
+impl io::Write for Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match *self {
+            Tcp(ref mut s) => s.write(buf),
+            Ssl(ref mut s) => s.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            Tcp(ref mut s) => s.flush(),
+            Ssl(ref mut s) => s.flush(),
+        }
+    }
+}
+
+// Clonable TLS Stream
+#[derive(Debug, Clone)]
+pub struct SslStream(Arc<Mutex<ssl::SslStream<TcpStream>>>);
+
+impl SslStream {
+    pub fn new(stream: ssl::SslStream<TcpStream>) -> SslStream {
+        SslStream(Arc::new(Mutex::new(stream)))
+    }
+
+    pub fn as_tcp(&self) -> io::Result<TcpStream> {
+        self.0.lock().unwrap().get_ref().try_clone()
+    }
+}
+
+impl io::Read for SslStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().read(buf)
+    }
+}
+
+impl io::Write for SslStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}

--- a/src/tls_config.rs
+++ b/src/tls_config.rs
@@ -1,0 +1,55 @@
+extern crate openssl;
+
+use errors::*;
+use std::fmt;
+use self::openssl::ssl::{SslConnectorBuilder, SslMethod, SslConnector};
+use self::openssl::x509::X509;
+use self::openssl::pkey::PKey;
+
+#[derive(Clone)]
+pub struct TlsConfig(SslConnector);
+
+pub struct TlsConfigBuilder(SslConnectorBuilder);
+
+impl TlsConfigBuilder {
+    pub fn new() -> Result<TlsConfigBuilder, NatsError> {
+        Ok(TlsConfigBuilder(
+            try!(SslConnectorBuilder::new(SslMethod::tls())),
+        ))
+    }
+
+    pub fn add_root_certificate<'a>(&'a mut self, cert: X509) -> Result<&'a mut Self, NatsError> {
+        try!(self.0.builder_mut().cert_store_mut().add_cert(cert));
+        Ok(self)
+    }
+
+    pub fn add_client_certificate<'a>(
+        &'a mut self,
+        cert: X509,
+        key: PKey,
+    ) -> Result<&'a mut Self, NatsError> {
+        {
+            let ctx = self.0.builder_mut();
+            try!(ctx.set_certificate(&cert));
+            try!(ctx.set_private_key(&key));
+            try!(ctx.check_private_key());
+        }
+        Ok(self)
+    }
+
+    pub fn build(self) -> TlsConfig {
+        TlsConfig(self.0.build())
+    }
+}
+
+impl TlsConfig {
+    pub fn as_connector(self) -> SslConnector {
+        self.0
+    }
+}
+
+impl fmt::Debug for TlsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TlsConfig {{}}")
+    }
+}


### PR DESCRIPTION
This PR adds TLS support (#5).

I implement it using [openssl](https://crates.io/crates/openssl) crate and exported it publicly to avoid *dependency of dependency* problem.

OpenSSL provides `SslStream` struct to wrap Tcp connection. But this struct is not Cloneable and holds ssl context internally. Since the current implementation requires a separate `stream_writer` and `buf_reader`, I had to wrap it with `Arc` and `Mutex`:
```rust
pub struct SslStream(Arc<Mutex<ssl::SslStream<TcpStream>>>);
```

To provide simultaneous support for TCP and SSL, and I made a separate enum `Stream`:
```rust
pub enum Stream {
    Tcp(TcpStream),
    Ssl(SslStream),
}
```
Complete implementation is in the file `stream.rs`.

To configure TLS options, structures `TlsConfig` and `TlsConfigBuilder` were added. It allows to add root CAs for self-signed certificates and client certificate/key.

Also I changed the result type of `try_connect` method to `Result<(), NatsError>`. This allowed me to handle tls connection errors and return the appropriate error.  Maybe in the future it will be useful for something else.