### PR TITLE
Handle OK after PING

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -694,9 +694,8 @@ fn wait_ok(state: &mut ClientState, verbose: bool) -> Result<(), NatsError> {
     if !verbose {
         return Ok(());
     }
-    let buf_reader = &mut state.buf_reader;
     let mut line = String::new();
-    match buf_reader.read_line(&mut line) {
+    match (&mut state.buf_reader).read_line(&mut line) {
         Ok(line_len) if line_len < "OK\r\n".len() => {
             return Err(NatsError::from((
                 ErrorKind::ServerProtocolError,
@@ -707,20 +706,20 @@ fn wait_ok(state: &mut ClientState, verbose: bool) -> Result<(), NatsError> {
         Ok(_) => {}
     };
     match line.as_ref() {
-        "+OK\r\n" => {}
+        "+OK\r\n" => Ok(()),
         "PING\r\n" => {
             let pong = b"PONG\r\n";
             state.stream_writer.write_all(pong)?;
+            wait_ok(state, verbose)
         }
         _ => {
-            return Err(NatsError::from((
+            Err(NatsError::from((
                 ErrorKind::ServerProtocolError,
                 "Received unexpected response from the server",
                 line,
             )))
         }
     }
-    Ok(())
 }
 
 fn wait_read_msg(


### PR DESCRIPTION
After receiving `PING`, it is required to wait for `OK` message in `wait_ok` function.
Otherwise it is possible to block forever while waiting for next message after publishing one.

Example code which blocks after server ping (two minutes in my case):
```rust
client.subscribe("subject.text", None).unwrap();
loop {
    client.publish("subject.test", "msg".as_bytes()).unwrap();
    if let Some(event) = client.events().next() {
        println!("{}: - {}", event.subject, String::from_utf8(event.msg).unwrap());
    }
    thread::sleep(Duration::from_millis(1000));
}
```