### PR TITLE
Implemented Clone trait for nats::Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -126,6 +126,29 @@ pub struct Events<'t> {
     client: &'t mut Client,
 }
 
+impl Clone for Client {
+    fn clone(&self) -> Self {
+        let mut client_clone = Client {
+            servers_info: self.servers_info.clone(),
+            server_idx: self.server_idx.clone(),
+            verbose: self.verbose.clone(),
+            pedantic: self.pedantic.clone(),
+            name: self.name.clone(),
+            state: None,
+            circuit_breaker: None,
+            sid: self.sid.clone(),
+            tls_config: self.tls_config.clone(),
+            subscriptions: self.subscriptions.clone(),
+        };
+
+        if self.state.is_some() {
+            let _ = client_clone.connect();
+        }
+
+        client_clone
+    }
+}
+
 impl Client {
     pub fn new<T: ToStringVec>(uris: T) -> Result<Client, NatsError> {
         let mut servers_info = Vec::new();


### PR DESCRIPTION
Hello!

I'm back with another PR, which is the ability to clone nats::Client (and make it re-connect post-clone if it was before).

Can you please review the code and check that I didn't do anything wrong? Tested it on my side without issues, but who knows!

Cheers,
Thanks,
Mathieu Amiot